### PR TITLE
1 more zoom lvl + padding around markers

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,7 @@ const hopeport_portal_stone_image_x = 4537
 const hopeport_portal_stone_image_y = 3432
 // Min and max zoom of the map (based on number of generated layers)
 const minZoom = 0
-const maxZoom = 7
+const maxZoom = 8
 
 /* Map Properties */
 // Desired map coordinate of the Hopeport Portal Stone
@@ -25,7 +25,7 @@ const basemap_error_url = `https://brightershoreswiki.org/images/Brighter_Shores
 const room_overlay_url = `https://brightershoreswiki.org/images/Brighter_Shores_World_Map_Overlay_{z}_{y}_{x}.png?${cache_buster}`
 const room_overlay_error_url = `https://brightershoreswiki.org/images/Brighter_Shores_World_Map_Overlay_blank.png?${cache_buster}`
 // When to switch between Room data and Entity data
-const room_entity_zoom_cutoff = 5.5
+const room_entity_zoom_cutoff = 6.5
 
 /* Tile Hover */
 const tile_hover_style = {
@@ -66,7 +66,7 @@ const episode_style = (feature) => ({
     fillOpacity: 0.2,
 })
 // Room default zoom on page load
-const room_zoom = 4
+const room_zoom = 5
 
 /* Entities */
 // Minimum size of entities even when you zoom out a lot

--- a/src/config.js
+++ b/src/config.js
@@ -89,7 +89,7 @@ const highlighted_entity_icon = L.icon({
 // How many extra tiles to display around the highlighted selected entries
 const highlighted_entity_margin = 5
 // Want 1/12 of a tile gap on all sides of an entity
-const entity_padding = tile_width / 12
+const entity_padding = 1/12
 
 /* Misc */
 const href = 'https://brightershoreswiki.org/w/'

--- a/src/config.js
+++ b/src/config.js
@@ -11,9 +11,9 @@ const tile_width = 48
 // Pixel of the Hopeport Portal Stone in the image
 const hopeport_portal_stone_image_x = 4537
 const hopeport_portal_stone_image_y = 3432
-// Min and max zoom of the map (based on number of generated layers)
-const minZoom = 0
-const maxZoom = 8
+// Min and max zoom level at which tiles are rendered
+const min_native_zoom = 0
+const max_native_zoom = 7
 
 /* Map Properties */
 // Desired map coordinate of the Hopeport Portal Stone
@@ -26,6 +26,9 @@ const room_overlay_url = `https://brightershoreswiki.org/images/Brighter_Shores_
 const room_overlay_error_url = `https://brightershoreswiki.org/images/Brighter_Shores_World_Map_Overlay_blank.png?${cache_buster}`
 // When to switch between Room data and Entity data
 const room_entity_zoom_cutoff = 6.5
+// Min and max zoom of the map
+const min_zoom = 0
+const max_zoom = 8
 
 /* Tile Hover */
 const tile_hover_style = {
@@ -85,6 +88,8 @@ const highlighted_entity_icon = L.icon({
 })
 // How many extra tiles to display around the highlighted selected entries
 const highlighted_entity_margin = 5
+// Want 1/12 of a tile gap on all sides of an entity
+const entity_padding = tile_width / 12
 
 /* Misc */
 const href = 'https://brightershoreswiki.org/w/'
@@ -101,8 +106,10 @@ module.exports = {
     tile_width,
     hopeport_portal_stone_image_x,
     hopeport_portal_stone_image_y,
-    minZoom,
-    maxZoom,
+    min_zoom,
+    max_zoom,
+    min_native_zoom,
+    max_native_zoom,
     hopeport_portal_stone_coord_x,
     hopeport_portal_stone_coord_y,
     basemap_url,
@@ -118,6 +125,7 @@ module.exports = {
     entity_minimum_width,
     highlighted_entity_icon,
     highlighted_entity_margin,
+    entity_padding,
     href,
     minimum_characters_in_automatic_search,
     world_dimensions,

--- a/src/index.js
+++ b/src/index.js
@@ -16,16 +16,16 @@ if(ENV.IMPORT_JSON === true) {
 const basemap = L.tileLayer(config.basemap_url, {
     errorTileUrl: config.basemap_error_url,
     noWrap: true,
-    minNativeZoom: config.minZoom,
-    maxNativeZoom: config.maxZoom-1,
+    minNativeZoom: config.min_native_zoom,
+    maxNativeZoom: config.max_native_zoom,
     tileSize: config.image_tile_dimensions,
 })
 const map = L.map('map', {
     crs: map_dimensions.CRS,
     bounds: map_dimensions.bounds,
     maxBounds: map_dimensions.bounds,
-    minZoom: config.minZoom,
-    maxZoom: config.maxZoom,
+    minZoom: config.min_zoom,
+    maxZoom: config.max_zoom,
     layers: [basemap],
     fullscreenControl: true,
     fullScreenControlOptions: {

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const basemap = L.tileLayer(config.basemap_url, {
     errorTileUrl: config.basemap_error_url,
     noWrap: true,
     minNativeZoom: config.minZoom,
-    maxNativeZoom: config.maxZoom,
+    maxNativeZoom: config.maxZoom-1,
     tileSize: config.image_tile_dimensions,
 })
 const map = L.map('map', {

--- a/src/markers.js
+++ b/src/markers.js
@@ -9,7 +9,8 @@ const EntityMarker = L.Marker.extend({
     update_size() {
         const tile_width = this.entity_map.latLngToLayerPoint([0,1]).x - this.entity_map.latLngToLayerPoint([0,0]).x
         const icon = this.getIcon()
-        icon.options.iconSize = [Math.max(config.entity_minimum_width, tile_width*this.entity_size[0] - 2*config.entity_padding), Math.max(config.entity_minimum_width, tile_width*this.entity_size[1] - 2*config.entity_padding)]
+        const padding = 2*tile_width*config.entity_padding
+        icon.options.iconSize = [Math.max(config.entity_minimum_width, tile_width*this.entity_size[0] - padding), Math.max(config.entity_minimum_width, tile_width*this.entity_size[1] - padding)]
         this.setIcon(icon)
     },
 })

--- a/src/markers.js
+++ b/src/markers.js
@@ -8,9 +8,8 @@ const adjust_coordinates = (latlng, size) => [latlng.lat + size[1]/2, latlng.lng
 const EntityMarker = L.Marker.extend({
     update_size() {
         const tile_width = this.entity_map.latLngToLayerPoint([0,1]).x - this.entity_map.latLngToLayerPoint([0,0]).x
-        const padding = tile_width / 6  // want there to be small gap between icon and tile boundary
         const icon = this.getIcon()
-        icon.options.iconSize = [Math.max(config.entity_minimum_width, tile_width*this.entity_size[0]-padding), Math.max(config.entity_minimum_width, tile_width*this.entity_size[1]-padding)]
+        icon.options.iconSize = [Math.max(config.entity_minimum_width, tile_width*this.entity_size[0] - 2*config.entity_padding), Math.max(config.entity_minimum_width, tile_width*this.entity_size[1] - 2*config.entity_padding)]
         this.setIcon(icon)
     },
 })

--- a/src/markers.js
+++ b/src/markers.js
@@ -8,8 +8,9 @@ const adjust_coordinates = (latlng, size) => [latlng.lat + size[1]/2, latlng.lng
 const EntityMarker = L.Marker.extend({
     update_size() {
         const tile_width = this.entity_map.latLngToLayerPoint([0,1]).x - this.entity_map.latLngToLayerPoint([0,0]).x
+        const padding = tile_width / 6  // want there to be small gap between icon and tile boundary
         const icon = this.getIcon()
-        icon.options.iconSize = [Math.max(config.entity_minimum_width, tile_width*this.entity_size[0]), Math.max(config.entity_minimum_width, tile_width*this.entity_size[1])]
+        icon.options.iconSize = [Math.max(config.entity_minimum_width, tile_width*this.entity_size[0]-padding), Math.max(config.entity_minimum_width, tile_width*this.entity_size[1]-padding)]
         this.setIcon(icon)
     },
 })

--- a/src/room_overlay.js
+++ b/src/room_overlay.js
@@ -67,7 +67,7 @@ const setup_room_overlay = (map) => {
         errorTileUrl: config.room_overlay_error_url,
         noWrap: true,
         minNativeZoom: config.minZoom,
-        maxNativeZoom: config.maxZoom,
+        maxNativeZoom: config.maxZoom-1,
         tileSize: config.image_tile_dimensions,
     })
     add_room_overlay_update_event(map)

--- a/src/room_overlay.js
+++ b/src/room_overlay.js
@@ -66,8 +66,8 @@ const setup_room_overlay = (map) => {
     room_overlay_layer = L.tileLayer(config.room_overlay_url, {
         errorTileUrl: config.room_overlay_error_url,
         noWrap: true,
-        minNativeZoom: config.minZoom,
-        maxNativeZoom: config.maxZoom-1,
+        minNativeZoom: config.min_native_zoom,
+        maxNativeZoom: config.max_native_zoom,
         tileSize: config.image_tile_dimensions,
     })
     add_room_overlay_update_event(map)


### PR DESCRIPTION
Allow zooming in 1 extra level, and add a bit of space around the entity icons. Example how it looks after:
![image](https://github.com/user-attachments/assets/20488e33-5acd-4cef-b79f-8d5ad84e2962)

See also: https://brightershoreswiki.org/w/User:Microbrews/Common.less/leaflet.less for a couple more changes -- adding shadow to the entity icons + making corners more rounded + at the very bottom I added `image-rendering:pixelated` hoping that will make the browser use nearest-neighbor when zooming into the max level. Not sure whether that was the right class to put it on though, but it worked when I put it on my user css anyway.