### PR TITLE
Entity + highlight marker z-index fixes

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -88,6 +88,9 @@ const highlighted_entity_icon = L.icon({
 })
 // How many extra tiles to display around the highlighted selected entries
 const highlighted_entity_margin = 5
+const max_entity_width = 10
+const zindex_offset_multiplier = max_entity_width*tile_width*2^(max_zoom - max_native_zoom)
+const highlighted_entity_zindex = max_entity_width^2*zindex_offset_multiplier
 // Want 1/12 of a tile gap on all sides of an entity
 const entity_padding = 1/12
 
@@ -125,6 +128,8 @@ module.exports = {
     entity_minimum_width,
     highlighted_entity_icon,
     highlighted_entity_margin,
+    zindex_offset_multiplier,
+    highlighted_entity_zindex,
     entity_padding,
     href,
     minimum_characters_in_automatic_search,

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -40,7 +40,7 @@ const highlight_entities = (map, entities, exact) => {
             const size = feature.properties.size
             const coordinates = markers.adjust_coordinates(latlng, size)
             const link = feature.properties.link ? feature.properties.link : feature.properties.name
-            return L.marker(coordinates, {icon: config.highlighted_entity_icon}).bindPopup(`<a class="leaflet-popup-highlighted-entity" href="${config.href}${link}">${feature.properties.name}</a>`)
+            return L.marker(coordinates, {icon: config.highlighted_entity_icon, zIndexOffset:config.highlighted_entity_zindex}).bindPopup(`<a class="leaflet-popup-highlighted-entity" href="${config.href}${link}">${feature.properties.name}</a>`)
         }
     })
     highlighted_entity_layer.addTo(map)

--- a/src/markers.js
+++ b/src/markers.js
@@ -4,6 +4,8 @@ const config = require('./config.js')
 let entity_layer = null
 
 const adjust_coordinates = (latlng, size) => [latlng.lat + size[1]/2, latlng.lng + size[0]/2]
+// smaller markers go above larger ones, but always below highlighted entities
+const adjust_zindex = (size) => config.highlighted_entity_zindex - config.zindex_offset_multiplier*size[0]*size[1]
 
 const EntityMarker = L.Marker.extend({
     update_size() {
@@ -23,7 +25,7 @@ const add_entities = (map) => {
         const icon = L.divIcon({className: 'leaflet-marker-icon-entity ' + feature.properties.classes.map(classname => `leaflet-marker-icon-${classname}`).join(' ')})
         const size = feature.properties.size
         const coordinates = adjust_coordinates(latlng, size)
-        const marker = new EntityMarker(coordinates, {icon})
+        const marker = new EntityMarker(coordinates, {icon, zIndexOffset: adjust_zindex(size)})
         marker.entity_size = size
         marker.entity_map = map
         marker.update_size()


### PR DESCRIPTION
Highlight markers always go on top, and smaller entity markers go on top of larger ones. This may not be the most elegant solution.

Before:
![image](https://github.com/user-attachments/assets/33001678-b941-4e26-9866-0c36147ad5a2)

After:
![image](https://github.com/user-attachments/assets/a7aa3868-7380-472e-8a80-675fa7b2ba0b)

~~The commits got very messed up on #3 but it's only a few lines so I'm just opening a new PR. Sorry about that~~ nvm the original one should be good now